### PR TITLE
refactor: remove duplicate duration parser

### DIFF
--- a/app.js
+++ b/app.js
@@ -67,29 +67,9 @@ function parseSummary(text) {
   return events;
 }
 
-// More flexible duration parser
-function parseDuration(str) {
-  str = str.toLowerCase().trim();
-
-  if (str.endsWith("h")) return parseFloat(str);
-  if (str.includes("hour")) {
-    const hm = str.match(/(\\d+)\\s*hour[s]?\\s*(\\d+)?/);
-    if (hm) return parseInt(hm[1],10) + (hm[2]?parseInt(hm[2],10)/60:0);
-  }
-  if (str.includes("min")) {
-    const m = str.match(/(\\d+)/);
-    if (m) return parseInt(m[1],10)/60;
-  }
-  if (str.endsWith("m")) return parseInt(str,10)/60;
-  const f = parseFloat(str);
-  return isNaN(f) ? 0 : f;
-}
-
-
-
-// Convert various duration formats to hours (float)
-function parseDuration(str) {
-  str = str.toLowerCase().trim();
+  // Convert various duration formats to hours (float)
+  function parseDuration(str) {
+    str = str.toLowerCase().trim();
 
   // 1. Simple numbers with h
   if (/^\d+(\.\d+)?h$/.test(str)) {


### PR DESCRIPTION
## Summary
- Remove earlier `parseDuration` implementation
- Keep comprehensive duration parser
- Ensure `parseSummary` leverages the flexible parser

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a85687491c83289e3988e51dafbb35