### PR TITLE
feat: parse more meeting formats

### DIFF
--- a/test/parseSummary.test.js
+++ b/test/parseSummary.test.js
@@ -1,0 +1,56 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+// Polyfill minimal localStorage before requiring app.js
+global.localStorage = {
+  getItem: () => null,
+  setItem: () => {}
+};
+
+const { parseSummary } = require('../app.js');
+
+const sampleDay = 'Mon';
+
+function wrap(text) {
+  return `${sampleDay}\n${text}`;
+}
+
+test('parses hyphen with parentheses', () => {
+  const events = parseSummary(wrap('09:00-10:00 Standup (1h)'));
+  assert.strictEqual(events.length, 1);
+  const evt = events[0];
+  assert.strictEqual(evt.start, '09:00');
+  assert.strictEqual(evt.end, '10:00');
+  assert.strictEqual(evt.title, 'Standup');
+  assert.strictEqual(evt.duration, 1);
+});
+
+test('parses en dash separator', () => {
+  const events = parseSummary(wrap('09:00–10:00 Planning (1h)'));
+  assert.strictEqual(events.length, 1);
+  const evt = events[0];
+  assert.strictEqual(evt.start, '09:00');
+  assert.strictEqual(evt.end, '10:00');
+  assert.strictEqual(evt.title, 'Planning');
+  assert.strictEqual(evt.duration, 1);
+});
+
+test('parses hyphen without parentheses', () => {
+  const events = parseSummary(wrap('09:00-09:30 Sync 30m'));
+  assert.strictEqual(events.length, 1);
+  const evt = events[0];
+  assert.strictEqual(evt.start, '09:00');
+  assert.strictEqual(evt.end, '09:30');
+  assert.strictEqual(evt.title, 'Sync');
+  assert.strictEqual(evt.duration, 0.5);
+});
+
+test('parses "to" separator without parentheses', () => {
+  const events = parseSummary(wrap('10:00 to 11:00 Review 1h'));
+  assert.strictEqual(events.length, 1);
+  const evt = events[0];
+  assert.strictEqual(evt.start, '10:00');
+  assert.strictEqual(evt.end, '11:00');
+  assert.strictEqual(evt.title, 'Review');
+  assert.strictEqual(evt.duration, 1);
+});


### PR DESCRIPTION
## Summary
- extend meeting line parsing to support en dashes, `to`, and duration without parentheses
- add unit tests covering multiple meeting line formats

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68a8568e3c148328bbf0723c3fc012d7