### PR TITLE
Add reset and export options for rule management

### DIFF
--- a/app.js
+++ b/app.js
@@ -240,3 +240,17 @@ function addRule() {
   renderRules();
 }
 
+function resetRules() {
+  localStorage.removeItem("rules");
+  rules = [];
+  renderRules();
+}
+
+function exportRules() {
+  const blob = new Blob([JSON.stringify(rules, null, 2)], { type: "application/json" });
+  const a = document.createElement("a");
+  a.href = URL.createObjectURL(blob);
+  a.download = "rules.json";
+  a.click();
+}
+

--- a/app.js
+++ b/app.js
@@ -67,26 +67,6 @@ function parseSummary(text) {
   return events;
 }
 
-// More flexible duration parser
-function parseDuration(str) {
-  str = str.toLowerCase().trim();
-
-  if (str.endsWith("h")) return parseFloat(str);
-  if (str.includes("hour")) {
-    const hm = str.match(/(\\d+)\\s*hour[s]?\\s*(\\d+)?/);
-    if (hm) return parseInt(hm[1],10) + (hm[2]?parseInt(hm[2],10)/60:0);
-  }
-  if (str.includes("min")) {
-    const m = str.match(/(\\d+)/);
-    if (m) return parseInt(m[1],10)/60;
-  }
-  if (str.endsWith("m")) return parseInt(str,10)/60;
-  const f = parseFloat(str);
-  return isNaN(f) ? 0 : f;
-}
-
-
-
 // Convert various duration formats to hours (float)
 function parseDuration(str) {
   str = str.toLowerCase().trim();

--- a/app.js
+++ b/app.js
@@ -20,6 +20,41 @@ function handleParse() {
   parsedEvents = parseSummary(text);
   renderCategorization();
 }
+function parseDuration(str) {
+  str = str.toLowerCase().trim();
+
+  // 1. Simple numbers with h
+  if (/^\d+(\.\d+)?h$/.test(str)) {
+    return parseFloat(str.replace("h", ""));
+  }
+
+  // 2. Hours + optional minutes
+  const hm = str.match(/(\d+)\s*hour[s]?\s*(\d+)?\s*min/);
+  if (hm) {
+    const hours = parseInt(hm[1], 10);
+    const mins = hm[2] ? parseInt(hm[2], 10) : 0;
+    return hours + mins / 60;
+  }
+
+  // 3. Hours only
+  const h = str.match(/(\d+)\s*hour[s]?/);
+  if (h) {
+    return parseInt(h[1], 10);
+  }
+
+  // 4. Minutes only
+  const m = str.match(/(\d+)\s*m(in(ute)?s?)?/);
+  if (m) {
+    return parseInt(m[1], 10) / 60;
+  }
+
+  // 5. Fallback: try to parse as number
+  const f = parseFloat(str);
+  if (!isNaN(f)) return f;
+
+  return 0; // default if unknown
+}
+
 function parseSummary(text) {
   const lines = text.split("\n").map(l => l.trim()).filter(l => l);
   const events = [];
@@ -31,42 +66,6 @@ function parseSummary(text) {
 
   // Detect meeting line: "09:15-09:45 Title (duration)"
   const meetingRegex = /^(\d{1,2}:\d{2})-(\d{1,2}:\d{2})\s+(.+?)\s+\((.+)\)$/;
-
-  // Convert various duration formats to hours (float)
-  function parseDuration(str) {
-    str = str.toLowerCase().trim();
-
-    // 1. Simple numbers with h
-    if (/^\d+(\.\d+)?h$/.test(str)) {
-      return parseFloat(str.replace("h", ""));
-    }
-
-    // 2. Hours + optional minutes
-    const hm = str.match(/(\d+)\s*hour[s]?\s*(\d+)?\s*min/);
-    if (hm) {
-      const hours = parseInt(hm[1], 10);
-      const mins = hm[2] ? parseInt(hm[2], 10) : 0;
-      return hours + mins / 60;
-    }
-
-    // 3. Hours only
-    const h = str.match(/(\d+)\s*hour[s]?/);
-    if (h) {
-      return parseInt(h[1], 10);
-    }
-
-    // 4. Minutes only
-    const m = str.match(/(\d+)\s*m(in(ute)?s?)?/);
-    if (m) {
-      return parseInt(m[1], 10) / 60;
-    }
-
-    // 5. Fallback: try to parse as number
-    const f = parseFloat(str);
-    if (!isNaN(f)) return f;
-
-    return 0; // default if unknown
-  }
 
   for (const line of lines) {
     if (dayRegex.test(line)) {

--- a/app.js
+++ b/app.js
@@ -20,40 +20,6 @@ function handleParse() {
   parsedEvents = parseSummary(text);
   renderCategorization();
 }
-function parseDuration(str) {
-  str = str.toLowerCase().trim();
-
-  // 1. Simple numbers with h
-  if (/^\d+(\.\d+)?h$/.test(str)) {
-    return parseFloat(str.replace("h", ""));
-  }
-
-  // 2. Hours + optional minutes
-  const hm = str.match(/(\d+)\s*hour[s]?\s*(\d+)?\s*min/);
-  if (hm) {
-    const hours = parseInt(hm[1], 10);
-    const mins = hm[2] ? parseInt(hm[2], 10) : 0;
-    return hours + mins / 60;
-  }
-
-  // 3. Hours only
-  const h = str.match(/(\d+)\s*hour[s]?/);
-  if (h) {
-    return parseInt(h[1], 10);
-  }
-
-  // 4. Minutes only
-  const m = str.match(/(\d+)\s*m(in(ute)?s?)?/);
-  if (m) {
-    return parseInt(m[1], 10) / 60;
-  }
-
-  // 5. Fallback: try to parse as number
-  const f = parseFloat(str);
-  if (!isNaN(f)) return f;
-
-  return 0; // default if unknown
-}
 
 function parseSummary(text) {
   const lines = text.split("\n").map(l => l.trim()).filter(l => l);
@@ -100,6 +66,42 @@ function parseSummary(text) {
   }
 
   return events;
+}
+
+// Convert various duration formats to hours (float)
+function parseDuration(str) {
+  str = str.toLowerCase().trim();
+
+  // 1. Simple numbers with h
+  if (/^\d+(\.\d+)?h$/.test(str)) {
+    return parseFloat(str.replace("h", ""));
+  }
+
+  // 2. Hours + optional minutes
+  const hm = str.match(/(\d+)\s*hour[s]?\s*(\d+)?\s*min/);
+  if (hm) {
+    const hours = parseInt(hm[1], 10);
+    const mins = hm[2] ? parseInt(hm[2], 10) : 0;
+    return hours + mins / 60;
+  }
+
+  // 3. Hours only
+  const h = str.match(/(\d+)\s*hour[s]?/);
+  if (h) {
+    return parseInt(h[1], 10);
+  }
+
+  // 4. Minutes only
+  const m = str.match(/(\d+)\s*m(in(ute)?s?)?/);
+  if (m) {
+    return parseInt(m[1], 10) / 60;
+  }
+
+  // 5. Fallback: try to parse as number
+  const f = parseFloat(str);
+  if (!isNaN(f)) return f;
+
+  return 0; // default if unknown
 }
 
 

--- a/app.js
+++ b/app.js
@@ -32,6 +32,42 @@ function parseSummary(text) {
   // Detect meeting line: "09:15-09:45 Title (duration)"
   const meetingRegex = /^(\d{1,2}:\d{2})-(\d{1,2}:\d{2})\s+(.+?)\s+\((.+)\)$/;
 
+  // Convert various duration formats to hours (float)
+  function parseDuration(str) {
+    str = str.toLowerCase().trim();
+
+    // 1. Simple numbers with h
+    if (/^\d+(\.\d+)?h$/.test(str)) {
+      return parseFloat(str.replace("h", ""));
+    }
+
+    // 2. Hours + optional minutes
+    const hm = str.match(/(\d+)\s*hour[s]?\s*(\d+)?\s*min/);
+    if (hm) {
+      const hours = parseInt(hm[1], 10);
+      const mins = hm[2] ? parseInt(hm[2], 10) : 0;
+      return hours + mins / 60;
+    }
+
+    // 3. Hours only
+    const h = str.match(/(\d+)\s*hour[s]?/);
+    if (h) {
+      return parseInt(h[1], 10);
+    }
+
+    // 4. Minutes only
+    const m = str.match(/(\d+)\s*m(in(ute)?s?)?/);
+    if (m) {
+      return parseInt(m[1], 10) / 60;
+    }
+
+    // 5. Fallback: try to parse as number
+    const f = parseFloat(str);
+    if (!isNaN(f)) return f;
+
+    return 0; // default if unknown
+  }
+
   for (const line of lines) {
     if (dayRegex.test(line)) {
       currentDay = line.slice(0,3); // Normalize to Mon/Tue/…
@@ -65,42 +101,6 @@ function parseSummary(text) {
   }
 
   return events;
-}
-
-// Convert various duration formats to hours (float)
-function parseDuration(str) {
-  str = str.toLowerCase().trim();
-
-  // 1. Simple numbers with h
-  if (/^\d+(\.\d+)?h$/.test(str)) {
-    return parseFloat(str.replace("h", ""));
-  }
-
-  // 2. Hours + optional minutes
-  const hm = str.match(/(\d+)\s*hour[s]?\s*(\d+)?\s*min/);
-  if (hm) {
-    const hours = parseInt(hm[1], 10);
-    const mins = hm[2] ? parseInt(hm[2], 10) : 0;
-    return hours + mins / 60;
-  }
-
-  // 3. Hours only
-  const h = str.match(/(\d+)\s*hour[s]?/);
-  if (h) {
-    return parseInt(h[1], 10);
-  }
-
-  // 4. Minutes only
-  const m = str.match(/(\d+)\s*m(in(ute)?s?)?/);
-  if (m) {
-    return parseInt(m[1], 10) / 60;
-  }
-
-  // 5. Fallback: try to parse as number
-  const f = parseFloat(str);
-  if (!isNaN(f)) return f;
-
-  return 0; // default if unknown
 }
 
 

--- a/index.html
+++ b/index.html
@@ -43,9 +43,7 @@
     <button onclick="exportRules()">Export Rules</button>
   </section>
 
-  <script src="app.js">
-    <script src="app.js?v=2"></script>
-  </script>
+  <script src="app.js?v=2"></script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -39,6 +39,8 @@
     <h2>Rules Management</h2>
     <table id="rulesTable" border="1" cellpadding="5"></table>
     <button onclick="addRule()">Add New Rule</button>
+    <button onclick="resetRules()">Reset Rules</button>
+    <button onclick="exportRules()">Export Rules</button>
   </section>
 
   <script src="app.js">


### PR DESCRIPTION
## Summary
- Add Reset Rules and Export Rules controls to rules section
- Provide functions to clear stored rules and download existing rules as JSON

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a856962f688328855baf62c78895f6