### PR TITLE
Wire up parse meetings button and show parsed results

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,6 +63,25 @@
           <p class="help">Tip: Accepts lines like “09:15–09:45 Title (45m)”.</p>
         </section>
 
+      <!-- Categorization -->
+        <section
+          id="categorization"
+          class="hidden rounded-xl border border-slate-200 bg-white p-6 shadow dark:border-slate-800 dark:bg-slate-900"
+        >
+          <h2>Categorization</h2>
+          <div class="table-wrap">
+            <table id="eventsTable"></table>
+          </div>
+          <div class="actions">
+            <button
+              id="generateBtn"
+              class="rounded-lg bg-slate-900 px-4 py-2 font-semibold text-slate-50 hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200"
+            >
+              Generate timesheet
+            </button>
+          </div>
+        </section>
+
       <!-- Timesheet -->
         <section
           id="timesheetSection"

--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,11 @@ import { initNavigation } from "./navigation.js";
 
 initNavigation();
 
+// Bind UI actions
+document.getElementById("parseBtn").addEventListener("click", handleParse);
+document.getElementById("generateBtn").addEventListener("click", generateTimesheet);
+document.getElementById("exportCsvBtn").addEventListener("click", exportCSV);
+
 // Expose functions for inline handlers
 Object.assign(window, {
   handleParse,


### PR DESCRIPTION
## Summary
- Add categorization section to display parsed meeting details
- Bind Parse and Generate buttons to render parsed events and timesheet
- Wire Export CSV button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a88251a1188328976e155e397035ca