### PR TITLE
Fix module loading errors by using CDN Tailwind and cleaning imports

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Timesheet Parser</title>
+    <script src="https://cdn.tailwindcss.com"></script>
   </head>
   <body class="bg-slate-50 text-slate-900 dark:bg-slate-950 dark:text-slate-100">
     <div class="container">
@@ -127,7 +128,7 @@
           <div class="table-wrap">
             <table id="rulesTable"></table>
           </div>
-        </section>
+    </section>
     </div>
     <script type="module" src="./src/main.js"></script>
     <link rel="stylesheet" href="styles.css" />

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,3 @@
-import "./tailwind.css";
 import {
   handleParse,
   renderCategorization,


### PR DESCRIPTION
## Summary
- Load Tailwind CSS from CDN instead of importing it as a module
- Remove Tailwind CSS import from main.js so JavaScript modules load correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a884b01fa88328a52383f389159e0d