### PR TITLE
Hide parser table when switching to rules

### DIFF
--- a/src/navigation.js
+++ b/src/navigation.js
@@ -4,6 +4,9 @@ export function initNavigation() {
     { btn: "#tab-timesheet", sec: "#timesheetSection" },
     { btn: "#tab-rules", sec: "#rulesSection" },
   ];
+  const categorization = document.querySelector("#categorization");
+  const eventsTable = document.querySelector("#eventsTable");
+
   const set = (active) => {
     tabs.forEach(({ btn, sec }) => {
       const b = document.querySelector(btn),
@@ -12,6 +15,12 @@ export function initNavigation() {
       b.setAttribute("aria-selected", on ? "true" : "false");
       s.classList.toggle("hidden", !on);
     });
+
+    if (active !== "#pasteSection") {
+      categorization.classList.add("hidden");
+    } else if (eventsTable.rows.length > 0) {
+      categorization.classList.remove("hidden");
+    }
   };
   tabs.forEach(({ btn, sec }) => {
     document.querySelector(btn).addEventListener("click", () => set(sec));


### PR DESCRIPTION
## Summary
- hide categorization table when leaving Paste tab so rules view is unobstructed
- restore categorization view when returning to Paste if events exist

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a88930a440832893855711bd18fbcf