### PR TITLE
Clear parsed events when switching tabs

### DIFF
--- a/src/navigation.js
+++ b/src/navigation.js
@@ -18,6 +18,7 @@ export function initNavigation() {
 
     if (active !== "#pasteSection") {
       categorization.classList.add("hidden");
+      eventsTable.innerHTML = "";
     } else if (eventsTable.rows.length > 0) {
       categorization.classList.remove("hidden");
     }


### PR DESCRIPTION
## Summary
- Clear parsed events table when moving away from the Paste tab to ensure Rules view is clean

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a88a0ec1e88328a5aca59e52a60122