### PR TITLE
Make input text readable in rules and event tables

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -20,10 +20,10 @@ export function renderRules() {
   rules.forEach((r, idx) => {
     const row = document.createElement("tr");
     row.innerHTML = `
-      <td><input value="${r.pattern}" onchange="updateRule(${idx}, 'pattern', this.value)"></td>
-      <td><input value="${r.category}" onchange="updateRule(${idx}, 'category', this.value)"></td>
-      <td><input value="${r.project}" onchange="updateRule(${idx}, 'project', this.value)"></td>
-      <td><input value="${r.task}" onchange="updateRule(${idx}, 'task', this.value)"></td>
+      <td><input class="text-black" value="${r.pattern}" onchange="updateRule(${idx}, 'pattern', this.value)"></td>
+      <td><input class="text-black" value="${r.category}" onchange="updateRule(${idx}, 'category', this.value)"></td>
+      <td><input class="text-black" value="${r.project}" onchange="updateRule(${idx}, 'project', this.value)"></td>
+      <td><input class="text-black" value="${r.task}" onchange="updateRule(${idx}, 'task', this.value)"></td>
       <td><button onclick="deleteRule(${idx})">Delete</button></td>
     `;
     table.appendChild(row);

--- a/src/ui.js
+++ b/src/ui.js
@@ -31,9 +31,9 @@ export function renderCategorization() {
       <td>${evt.date}</td>
       <td>${evt.title}</td>
       <td>${evt.duration}h</td>
-      <td><input value="${evt.category}" onchange="updateEvent(${idx}, 'category', this.value)"></td>
-      <td><input value="${evt.project}" onchange="updateEvent(${idx}, 'project', this.value)"></td>
-      <td><input value="${evt.task}" onchange="updateEvent(${idx}, 'task', this.value)"></td>
+      <td><input class="text-black" value="${evt.category}" onchange="updateEvent(${idx}, 'category', this.value)"></td>
+      <td><input class="text-black" value="${evt.project}" onchange="updateEvent(${idx}, 'project', this.value)"></td>
+      <td><input class="text-black" value="${evt.task}" onchange="updateEvent(${idx}, 'task', this.value)"></td>
     `;
     table.appendChild(row);
   });


### PR DESCRIPTION
## Summary
- Ensure rule input fields render black text for better contrast
- Apply same text color fix to event categorization inputs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8be34defc83289a3562dadbae958c